### PR TITLE
issue 5-6

### DIFF
--- a/scanner_test.go
+++ b/scanner_test.go
@@ -1,0 +1,110 @@
+package obreron
+
+import (
+    "errors"
+    "testing"
+
+    "github.com/profe-ajedrez/obreron/v3/dialect"
+)
+
+func TestScanPlaceholders_ConsumesDoubleQuestionAsLiteral(t *testing.T) {
+    out, n, err := scanPlaceholdersInto(nil, "data ?? 'k'")
+    if err != nil {
+        t.Fatalf("unexpected err: %v", err)
+    }
+    if n != 0 {
+        t.Fatalf("expected 0 placeholders, got=%d", n)
+    }
+    if string(out) != "data ? 'k'" {
+        t.Fatalf("unexpected output: %q", string(out))
+    }
+}
+
+func TestScanPlaceholders_ReplacesSingleQuestionWithMarker(t *testing.T) {
+    out, n, err := scanPlaceholdersInto(nil, "x = ? AND y = ?")
+    if err != nil {
+        t.Fatalf("unexpected err: %v", err)
+    }
+    if n != 2 {
+        t.Fatalf("expected 2 placeholders, got=%d", n)
+    }
+    // Expect markers in-place.
+    want := []byte("x = ")
+    want = append(want, placeholderMarker)
+    want = append(want, []byte(" AND y = ")...)
+    want = append(want, placeholderMarker)
+    if string(out) != string(want) {
+        t.Fatalf("unexpected output bytes: got=%v want=%v", out, want)
+    }
+}
+
+func TestScanPlaceholders_TripleQuestionIsLiteralPlusMarker(t *testing.T) {
+    out, n, err := scanPlaceholdersInto(nil, "a = ???")
+    if err != nil {
+        t.Fatalf("unexpected err: %v", err)
+    }
+    if n != 1 {
+        t.Fatalf("expected 1 placeholder, got=%d", n)
+    }
+    want := []byte("a = ?")
+    want = append(want, placeholderMarker)
+    if string(out) != string(want) {
+        t.Fatalf("unexpected output: got=%v want=%v", out, want)
+    }
+}
+
+func TestScanPlaceholders_EmptyIsOk(t *testing.T) {
+    out, n, err := scanPlaceholdersInto(nil, "")
+    if err != nil {
+        t.Fatalf("unexpected err: %v", err)
+    }
+    if n != 0 {
+        t.Fatalf("expected 0 placeholders, got=%d", n)
+    }
+    if len(out) != 0 {
+        t.Fatalf("expected empty out, got=%q", string(out))
+    }
+}
+
+func TestScanPlaceholders_ReservedMarkerIsError(t *testing.T) {
+    raw := "x = " + string([]byte{placeholderMarker})
+    _, _, err := scanPlaceholdersInto(nil, raw)
+    if !errors.Is(err, ErrReservedMarker) {
+        t.Fatalf("expected ErrReservedMarker, got=%v", err)
+    }
+}
+
+func TestAddFragment_PlaceholderMismatchDoesNotMutateState(t *testing.T) {
+    st := acquireStament(dialect.MySQL{})
+    defer releaseStament(st)
+
+    st.addFragment("WHERE", 1, "x = ? AND y = ?", 1) // mismatch
+
+    if st.err == nil {
+        t.Fatalf("expected err")
+    }
+    if !errors.Is(st.err, ErrPlaceholderMismatch) {
+        t.Fatalf("expected ErrPlaceholderMismatch, got=%v", st.err)
+    }
+    if len(st.buf) != 0 || len(st.segs) != 0 || len(st.params) != 0 {
+        t.Fatalf("expected no mutation on error, got buf=%d segs=%d params=%d", len(st.buf), len(st.segs), len(st.params))
+    }
+}
+
+func TestAddFragment_ReservedMarkerDoesNotMutateState(t *testing.T) {
+    st := acquireStament(dialect.MySQL{})
+    defer releaseStament(st)
+
+    raw := "x = " + string([]byte{placeholderMarker})
+    st.addFragment("WHERE", 1, raw, 1)
+
+    if st.err == nil {
+        t.Fatalf("expected err")
+    }
+    if !errors.Is(st.err, ErrReservedMarker) {
+        t.Fatalf("expected ErrReservedMarker, got=%v", st.err)
+    }
+    if len(st.buf) != 0 || len(st.segs) != 0 || len(st.params) != 0 {
+        t.Fatalf("expected no mutation on error, got buf=%d segs=%d params=%d", len(st.buf), len(st.segs), len(st.params))
+    }
+}

--- a/stament.go
+++ b/stament.go
@@ -1,8 +1,16 @@
 package obreron
 
-// NOTE: The core internal engine (stament/scanner/build) is implemented in
-// subsequent issues. This file anchors the internal types and keeps the package
-// structure stable.
+import (
+    "sync"
+
+    "github.com/profe-ajedrez/obreron/v3/dialect"
+)
+
+// NOTE: stament (intentionally misspelled for continuity with v2 internals)
+// is the internal core state shared by all statement builders.
+//
+// Builders are NOT concurrency-safe. One goroutine should use one builder.
+// A sync.Pool makes concurrent allocations of separate builders efficient.
 
 // segment describes a single SQL fragment stored inside stament.buf.
 //
@@ -37,4 +45,147 @@ func newSegment(start, length uint32, sType uint8, pIndex int32, pCount uint16) 
         pCount: pCount,
         sType:  sType,
     }
+}
+
+// placeholderMarker is written into stament.buf during scanning to mark a
+// positional parameter placeholder. It must never appear in generated SQL.
+const placeholderMarker byte = 0x1F
+
+// stament is the internal accumulation buffer for a single SQL statement.
+//
+// Invariants:
+//   - If err is non-nil, all mutating operations should become no-ops.
+//   - dialect may be nil only while the stament is in the pool (after reset).
+type stament struct {
+    buf       []byte
+    segs      []segment
+    params    []any
+    dialect   dialect.Dialect
+    err       error
+    lastSType uint8
+    flags     uint8
+}
+
+// stamentPool reuses internal buffers to reduce GC pressure.
+var stamentPool = sync.Pool{New: func() any {
+    return &stament{
+        buf:    make([]byte, 0, 256),
+        segs:   make([]segment, 0, 12),
+        params: make([]any, 0, 8),
+    }
+}}
+
+func acquireStament(d dialect.Dialect) *stament {
+    st := stamentPool.Get().(*stament)
+    // The pool may return a previously used stament; we always set dialect.
+    st.dialect = d
+    return st
+}
+
+func releaseStament(st *stament) {
+    st.reset()
+    stamentPool.Put(st)
+}
+
+func (st *stament) reset() {
+    st.buf = st.buf[:0]
+    st.segs = st.segs[:0]
+    st.params = st.params[:0]
+    st.err = nil
+    st.flags = 0
+    st.lastSType = 0
+    // Explicitly clear dialect to avoid retaining references.
+    st.dialect = nil
+}
+
+func (st *stament) setErr(op string, err error) {
+    if st.err != nil {
+        return
+    }
+    dialectName := ""
+    if st.dialect != nil {
+        dialectName = st.dialect.Name()
+    }
+    st.err = &BuildError{Op: op, Dialect: dialectName, Err: err}
+}
+
+// addFragment scans raw for placeholders, appends raw (with markers) to buf,
+// appends args to params, and records a segment.
+//
+// It follows the spec rules for ??/???:
+//   - ?? becomes a literal '?'
+//   - ? becomes placeholderMarker (0x1F)
+//   - ??? is interpreted as ?? + ? (greedy-left)
+//
+// On error, addFragment rolls back any buffer growth and does not mutate segs
+// or params.
+func (st *stament) addFragment(op string, sType uint8, raw string, args ...any) {
+    if st.err != nil {
+        return
+    }
+
+    origLen := len(st.buf)
+    start := uint32(origLen)
+
+    out, placeholders, scanErr := scanPlaceholdersInto(st.buf, raw)
+    if scanErr != nil {
+        st.buf = st.buf[:origLen]
+        st.setErr(op, scanErr)
+        return
+    }
+
+    if placeholders != len(args) {
+        st.buf = st.buf[:origLen]
+        st.setErr(op, ErrPlaceholderMismatch)
+        return
+    }
+    if placeholders > int(^uint16(0)) {
+        st.buf = st.buf[:origLen]
+        st.setErr(op, ErrTooManyParams)
+        return
+    }
+
+    // Commit buffer changes.
+    st.buf = out
+    length := uint32(len(st.buf) - origLen)
+
+    pCount := uint16(placeholders)
+    pIndex := int32(-1)
+    if pCount > 0 {
+        pIndex = int32(len(st.params))
+    }
+
+    // Append args.
+    if pCount > 0 {
+        st.params = append(st.params, args...)
+    }
+
+    st.segs = append(st.segs, newSegment(start, length, sType, pIndex, pCount))
+}
+
+// scanPlaceholdersInto appends raw into dst while applying the placeholder rules.
+// It returns the updated dst, the number of placeholders found, and an error.
+func scanPlaceholdersInto(dst []byte, raw string) ([]byte, int, error) {
+    placeholders := 0
+    for i := 0; i < len(raw); {
+        b := raw[i]
+        if b == placeholderMarker {
+            return dst, placeholders, ErrReservedMarker
+        }
+        if b == '?' {
+            // Greedy-left: consume ?? as a literal '?'
+            if i+1 < len(raw) && raw[i+1] == '?' {
+                dst = append(dst, '?')
+                i += 2
+                continue
+            }
+            dst = append(dst, placeholderMarker)
+            placeholders++
+            i++
+            continue
+        }
+        dst = append(dst, b)
+        i++
+    }
+    return dst, placeholders, nil
 }

--- a/stament_pool_test.go
+++ b/stament_pool_test.go
@@ -1,0 +1,71 @@
+package obreron
+
+import (
+    "errors"
+    "testing"
+
+    "github.com/profe-ajedrez/obreron/v3/dialect"
+)
+
+func TestStamentResetClearsAllFieldsIncludingDialect(t *testing.T) {
+    st := acquireStament(dialect.MySQL{})
+    // Mutate state.
+    st.buf = append(st.buf, 'a', 'b')
+    st.segs = append(st.segs, newSegment(0, 2, 1, -1, 0))
+    st.params = append(st.params, 1, 2)
+    st.flags = 0xFF
+    st.lastSType = 7
+    st.setErr("WHERE", ErrPlaceholderMismatch)
+
+    releaseStament(st)
+
+    if st.dialect != nil {
+        t.Fatalf("expected dialect=nil after reset, got=%T", st.dialect)
+    }
+    if st.err != nil {
+        t.Fatalf("expected err=nil after reset, got=%v", st.err)
+    }
+    if st.flags != 0 || st.lastSType != 0 {
+        t.Fatalf("expected flags/lastSType reset to 0, got flags=%d last=%d", st.flags, st.lastSType)
+    }
+    if len(st.buf) != 0 || len(st.segs) != 0 || len(st.params) != 0 {
+        t.Fatalf("expected slices cleared, got buf=%d segs=%d params=%d", len(st.buf), len(st.segs), len(st.params))
+    }
+}
+
+func TestAcquireAlwaysAssignsDialect(t *testing.T) {
+    st := acquireStament(dialect.MySQL{})
+    releaseStament(st)
+
+    st2 := acquireStament(dialect.Postgres{})
+    defer releaseStament(st2)
+
+    if st2.dialect == nil {
+        t.Fatalf("expected dialect assigned")
+    }
+    if st2.dialect.Name() != (dialect.Postgres{}).Name() {
+        t.Fatalf("expected Postgres dialect, got=%s", st2.dialect.Name())
+    }
+}
+
+func TestSetErrFirstErrorWins(t *testing.T) {
+    st := acquireStament(dialect.MySQL{})
+    defer releaseStament(st)
+
+    st.setErr("WHERE", ErrPlaceholderMismatch)
+    st.setErr("FROM", ErrEmptyFrom)
+
+    if st.err == nil {
+        t.Fatalf("expected err set")
+    }
+    if !errors.Is(st.err, ErrPlaceholderMismatch) {
+        t.Fatalf("expected first error to win (ErrPlaceholderMismatch), got=%v", st.err)
+    }
+    var be *BuildError
+    if !errors.As(st.err, &be) {
+        t.Fatalf("expected BuildError wrapper, got=%T", st.err)
+    }
+    if be.Op != "WHERE" {
+        t.Fatalf("expected Op=WHERE, got=%s", be.Op)
+    }
+}


### PR DESCRIPTION
REF #15, #16  

stament.go

stament struct con buf, segs, params, dialect, err, flags, lastSType

sync.Pool + acquireStament(d) / releaseStament(st)

reset() que limpia todo y pone dialect=nil

setErr(op, err) con first-error-wins envolviendo en BuildError

placeholderMarker = 0x1F

scanPlaceholdersInto(...) con reglas:

?? → ? literal

? → marker 0x1F

??? → ?? + ? (greedy-left) ⇒ ? literal + marker

si el input contiene 0x1F → ErrReservedMarker

addFragment(...) que:

escanea + valida placeholders == len(args) o ErrPlaceholderMismatch

hace rollback del buf en error

no muta segs/params/buf si falla

Tests nuevos:

stament_pool_test.go (reset/dialect nil/re-asignación/first-error-wins)